### PR TITLE
Fix missing options hash, preventing class from being set on Select

### DIFF
--- a/app/components/resorcery/search/input.html.erb
+++ b/app/components/resorcery/search/input.html.erb
@@ -1,6 +1,6 @@
 <%= form.label attribute, label, class: 'form-label text-light mb-0 text-nowrap' %>
 <% if data_type == :boolean %>
-  <%= form.select attribute, options_for_select([['Any', nil], ['Yes', true], ['No', false]], form.object.send(attribute)), class: 'form-select form-select-sm' %>
+  <%= form.select attribute, options_for_select([['Any', nil], ['Yes', true], ['No', false]], form.object.send(attribute)), {}, {class: 'form-select form-select-sm'} %>
 <% elsif data_type == :date %>
   <%= form.date_field attribute, class: 'form-control form-control-sm' %>
 <% elsif data_type == :number %>


### PR DESCRIPTION
Select element for search input was missing extra options hash, preventing HTML class from being set.